### PR TITLE
Features unittestsformvpinput processing

### DIFF
--- a/MoabTests/Models.Helpers/ExerciseImportHelperShould.cs
+++ b/MoabTests/Models.Helpers/ExerciseImportHelperShould.cs
@@ -346,7 +346,7 @@ namespace MoabTests.Models.Helpers
             "Stand with your feet hip width apart and keep your legs straight as you shift weight from one foot to the other. ," +
             ",N,N,,STAB_012_X_StandingWeightShift,STAB_012 Standing Weight Shift";
             string input = validHeader + Environment.NewLine + inputLine;
-            var originalId = ((List<Exercise>)_existingExercises)[2].Id;
+            var originalId = _existingExercises.ToList()[2].Id;
             // Act
             var result = importer.ImportNoDelete(input, _existingExercises);
             // Assert


### PR DESCRIPTION
I found the problem in one of my unit tests that hadn't gotten the syntax change for that ICollections to list problem, because it was in two places. It is now fixed. Now the tests that aren't passing are a checkheader test that Cam wrote, and the two hint ones that my code doesn't support